### PR TITLE
Ryanmilllay exceptionjsontranslation

### DIFF
--- a/src/main/java/com/neu/wham/controllers/DataSourceController.java
+++ b/src/main/java/com/neu/wham/controllers/DataSourceController.java
@@ -3,13 +3,17 @@ package com.neu.wham.controllers;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
-
 import com.neu.wham.exceptions.LocationException;
 import com.neu.wham.model.Event;
 import com.neu.wham.services.GetEventService;
@@ -40,4 +44,10 @@ public class DataSourceController {
 		return getEventService.getEvents(lat, lon, rad, q);
 	}
    
+	@ExceptionHandler(LocationException.class)
+	public ResponseEntity<String> handleLocationException(LocationException le) {
+		HttpHeaders httpHeaders = new HttpHeaders();
+		httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+		return new ResponseEntity<String>("{\"error\": \"" + le.getLocalizedMessage() + "\"}", httpHeaders, HttpStatus.BAD_REQUEST);
+	}
 }

--- a/src/main/java/com/neu/wham/controllers/DataSourceController.java
+++ b/src/main/java/com/neu/wham/controllers/DataSourceController.java
@@ -50,4 +50,11 @@ public class DataSourceController {
 		httpHeaders.setContentType(MediaType.APPLICATION_JSON);
 		return new ResponseEntity<String>("{\"error\": \"" + le.getLocalizedMessage() + "\"}", httpHeaders, HttpStatus.BAD_REQUEST);
 	}
+	
+	@RequestMapping()
+	public ResponseEntity<String> catchAll() {
+		HttpHeaders httpHeaders = new HttpHeaders();
+		httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+		return new ResponseEntity<String>("{\"error\": \"URL does not match any endpoints.\"}", httpHeaders, HttpStatus.NOT_FOUND);
+	}
 }


### PR DESCRIPTION
The DataSourceController was barfing when validation exceptions were thrown.  We now handle LocationExceptions and respond with a 400 response and a JSON payload containing the error message.

We also now have a default handler.  For requests missing lat, lon, or r, we respond with a 404 and a simple JSON payload.
